### PR TITLE
Adding done call to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ lab.experiment('module that depends on GitHub OAuth', function() {
 	lab.after(function(done) {
 		// Remove all intercepts
 		nock.cleanAll();
+		done();
 	});
 });
 ```


### PR DESCRIPTION
It looks like the done() call is missing in the README example